### PR TITLE
Display optional text if no matching beer posts are found

### DIFF
--- a/includes/class-post-shortcodes.php
+++ b/includes/class-post-shortcodes.php
@@ -9,7 +9,7 @@ class Beer_Post_Type_Shortcode {
         add_shortcode( 'beer', array( $this, 'beer_list_shortcode' ) );
     }
      
-    public function beer_list_shortcode( $atts ) {
+    public function beer_list_shortcode( $atts, $content = null ) {
 
         ob_start();
 
@@ -220,6 +220,8 @@ class Beer_Post_Type_Shortcode {
 
         return $beerlist;
 
+        } else {
+            return $content;
         }
 
     }

--- a/readme.txt
+++ b/readme.txt
@@ -60,6 +60,12 @@ The shortcode can be adjusted to display the following:
 
 The image assigned as the "featured image" in the beer post will automatically display.
 
+= How do display alternate text if no beers are found? =
+
+The enclosing shortcode format can be used to specify text that should appear if no beers are found.
+
+`[beer category="malt-beverages"]These are not the beers you're looking for[/beer]`
+
 == Credit ==
 
 team-post-type - ​https://github.com/devinsays/team-post-type


### PR DESCRIPTION
This change adds the $content parameter to the shortcode callback
function to support enclosed content.  The enclosed content will be
returned if no beer post are returned based on the specified shortcode
attributes.  $content defaults to null to maintain backward
compatibility with previous self-closing shortcode usage.
